### PR TITLE
revert c5b3932 (permission for any requested URL)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,7 @@
   "options_page": "options/options.html",
   "permissions": [
     "webRequest",
-    "<all_urls>",
+    "https://signin.aws.amazon.com/saml",
     "storage",
     "downloads",
     "tabs"


### PR DESCRIPTION
This is no longer needed. <https://crbug.com/918137> rescoped the Chrome
change. You now only need permission for the initiator to intercept
**subresource** requests.  Intercepting top level navigation is permitted with
permission for only the AWS URL.

I tested it just fine on Chromium and Firefox for an AWS account for which I can only assume one profile. This matches the scenario in which #28 was breaking.

Please do more extensive tests, I'm only vaguely familiar with the SAML/STS dance.